### PR TITLE
sca_agg: By default, omit throughput measurement outliers.

### DIFF
--- a/sca_tools/sca_agg.py
+++ b/sca_tools/sca_agg.py
@@ -35,9 +35,10 @@ logging.basicConfig(level=os.environ.get('LOG_LEVEL', 'INFO'))
 @click.option('--throughput_column', default='throughput')
 @click.option('--throughput_errors_column', default='throughput_stddev')
 @click.option('--output_directory', default=None)
+@click.option('--clean', default=True)
 @click.argument('filenames', nargs=-1)
 def main(load_column, throughput_column, throughput_errors_column,
-         output_directory, filenames):
+         output_directory, clean, filenames):
     """sca_agg merges results from independent benchmarking measurements
     into a single CSV file for use in sca_fit. It assumes (and checks)
     that a single CSV file contains multiple trial measurements of
@@ -110,6 +111,9 @@ def main(load_column, throughput_column, throughput_errors_column,
                 df_spec.load.std(),
             )
             continue
+        if clean:
+            if df_spec.drop_outliers():
+                logging.warn('Dropped some throughput outliers!')
         frames.append(df_spec)
     result = dat.aggregate_frames(frames, load_column, throughput_column,
                                   throughput_errors_column)

--- a/sca_tools/sca_fit.py
+++ b/sca_tools/sca_fit.py
@@ -84,7 +84,7 @@ def main(load_column, throughput_column, throughput_errors_column, model_type,
         # within the realm of my understanding.
         model_fit = model.fit(data=df_spec.throughput.values,
                               load=df_spec.load.values, lambda_=1000,
-                              sigma_=0.1, kappa=0.001, weights=None)
+                              sigma_=0.1, kappa=0.001, weights=weights)
         graphs = usl.generate_graphs(model_fit, df_spec, title=basename,
                                      xlabel=load_column,
                                      ylabel=throughput_column)


### PR DESCRIPTION
Throughput measurements captured during a warm up phase show up as
outliers when looking at throughput histograms for a fixed-load. We
add an option (enabled by default), which removes outliers from the
throughput measurements processed by sca_agg, and then asserts that
the result is actually normally distributed. Because the resulting
data is not skewed by outliers, using weights during USL fit seems
substantially more successful.